### PR TITLE
alter method parse crawler stats

### DIFF
--- a/logparser/common.py
+++ b/logparser/common.py
@@ -185,17 +185,17 @@ class Common(object):
         text = re.sub(r"'(.+?)'", r'"\1"', text)
         text = re.sub(r'[bu]"(.+?)"', r'"\1"', text)
 
-        """ 
-            Infoprice 
+        """
+            Infoprice
             The 'spidermon' inserts information in python dict format, into the final scrapydweb log which generates an error in the json.loads() function.
             Changes made to attend the "crawlers" with lib Spidermon implemented.
         """
         bad_words = {
-            'None':  'null',
-            'True':  'true',
+            'None': 'null',
+            'True': 'true',
             'False': 'false'
         }
-        for word, word_replace  in bad_words.items():
+        for word, word_replace in bad_words.items():
             text = re.sub(word, word_replace, text)
 
         try:

--- a/logparser/common.py
+++ b/logparser/common.py
@@ -184,6 +184,20 @@ class Common(object):
         text = re.sub(r'(".*?)\'(.*?)\'(.*?")', r'\1_\2_\3', text)
         text = re.sub(r"'(.+?)'", r'"\1"', text)
         text = re.sub(r'[bu]"(.+?)"', r'"\1"', text)
+
+        """ 
+            Infoprice 
+            The 'spidermon' inserts information in python dict format, into the final scrapydweb log which generates an error in the json.loads() function.
+            Changes made to attend the "crawlers" with lib Spidermon implemented.
+        """
+        bad_words = {
+            'None':  'null',
+            'True':  'true',
+            'False': 'false'
+        }
+        for word, word_replace  in bad_words.items():
+            text = re.sub(word, word_replace, text)
+
         try:
             return json.loads(text)
         except ValueError as err:


### PR DESCRIPTION
**Problema:** 
Com a implementação da lib **spidermon**( até o momento somente para sefaz_ba ), são inseridas novas linhas no log final que é usado pelo scrapydweb para buscar informações do estado dos crawlers. 

O spidermon(basedo em python) retorna valores boolean como(True, False), e a função json.loads() usada na lib logparser espera uma string json com valores como(true, false). Isso gera erro no retorno do log, e por isso a interface do scrapydweb não consegue mostrar os valores de **pages** e **items** .

**Solução**:
Foi realizado um fork dessa lib e feito alterações dentro do método **parse_crawler_stats** incluindo validações  para substituir palavras que podem quebrar a função .

Mapeamento básico de palavras: **None**, **True** e **False** 